### PR TITLE
feat: read .markdownlint.json config file and merge it with the defau…

### DIFF
--- a/lib/ruleChecker.js
+++ b/lib/ruleChecker.js
@@ -5,6 +5,9 @@
 
 "use strict";
 
+const path = require("node:path").posix;
+const fs = require("fs");
+
 const markdownlint = require("markdownlint");
 const { allRulesDisabled, formatters } = require("./utils");
 
@@ -18,11 +21,15 @@ const check = (ruleId, context, src) => {
     [ruleId]: context.options[0] || true,
   });
 
-  const { text: errors } = markdownlint.sync({
-    strings: { text: src.getText() },
-    config,
-    resultVersion: 3,
-  });
+  const options = { strings: { text: src.getText() }, config, resultVersion: 3 };
+  const optionsPath = path.join(process.cwd(), ".markdownlint.json");
+
+  // if options file exists
+  if (fs.existsSync(optionsPath)) {
+    options.config = { ...options.config, ...require(optionsPath) };
+  }
+
+  const { text: errors } = markdownlint.sync(options);
 
   return errors;
 };


### PR DESCRIPTION
First solution to read a config file (same file name as the markdownlint package: `.markdownlint.json`) and merges the options with the default ones used by this package.

Solves #6 I think.

Probably is not the best place to read the config file (the file is read multiple times, every time a rule is going to be checked), but it's the place where the markdownlint object is imported and used, and I didn't want to change more code, just make this feature available in an easy way.